### PR TITLE
Make the dot in the domain part non-conditional

### DIFF
--- a/lib/email_validator.rb
+++ b/lib/email_validator.rb
@@ -19,7 +19,7 @@ class EmailValidator < ActiveModel::EachValidator
     alnumhy = "(?:#{alnum}|#{hyphen})"
     label_pattern = "#{alnum}(?:#{alnumhy}{,62}#{alnum}+)?"
     tld_pattern = '[[:alpha:]]{1,63}'
-    domain_pattern = "(?:#{label_pattern}\\.?)*#{tld_pattern}"
+    domain_pattern = "(?:#{label_pattern}\\.)*#{tld_pattern}"
     if options[:strict_mode]
       # Local-part matching
       atom_char = '[-\p{Cased_Letter}\p{Nd}+_!"\'#$%^&*{}/=?`\|~]'


### PR DESCRIPTION
The dot being optional makes little sense and what's more it causes
exponential complexity when checking an invalid mail such as
mail@domain.com11111111111111